### PR TITLE
Add bounding box constraints

### DIFF
--- a/src/CounterfactualMilp.py
+++ b/src/CounterfactualMilp.py
@@ -197,6 +197,27 @@ class CounterfactualMilp:
                 self.actionnabilityConstraints[f] = self.model.addConstr(
                     self.x_var_sol[f] == self.x0[0][f],
                     "ActionnabilityFixed_f" + str(f))
+    
+    def addBoundingBoxConstraints(self, boundingBox):
+        """
+        Add constraints to restrict the counterfactual solution to
+        the bounding box specified by the input parameter.
+        
+        :param boundingBox: list of tuples (min, max) for each feature.
+        if min or max is None, the corresponding constraint is not added.
+        """
+        self.BoundingBoxConstraints = dict()
+        if boundingBox is not None:
+            for f in range(self.nFeatures):
+                if self.featuresType[f] == FeatureType.Numeric:
+                    if boundingBox[f][0] is not None:    
+                        self.BoundingBoxConstraints[f] = self.model.addConstr(
+                        self.x_var_sol[f] >= boundingBox[f][0],
+                        "boundingBoxMin_f" + str(f))
+                    if boundingBox[f][1] is not None:
+                        self.BoundingBoxConstraints[f] = self.model.addConstr(
+                            self.x_var_sol[f] <= boundingBox[f][1],
+                            "boundingBoxMax_f" + str(f))
 
     def addOneHotEncodingConstraints(self):
         self.oneHotEncodingConstraints = dict()

--- a/src/DatasetReader.py
+++ b/src/DatasetReader.py
@@ -225,11 +225,12 @@ class DatasetReader:
 
     def __unscale_feature_values(self, x_exp):
         """ Convert the normalized features back to their full range. """
-        for f in range(len(x_exp)):
-            x_exp[f] = (x_exp[f] * (self.upperBoundsList[f]
+        x = np.zeros_like(x_exp)
+        for f in range(len(x)):
+            x[f] = (x_exp[f] * (self.upperBoundsList[f]
                         - self.lowerBoundsList[f])
                         + self.lowerBoundsList[f])
-        return x_exp
+        return x
 
     # -- Public methods --
     def format_explanation(self, x_exp):

--- a/src/DecisionTreeCounterFactual.py
+++ b/src/DecisionTreeCounterFactual.py
@@ -15,6 +15,7 @@ class DecisionTreeCounterFactualMilp(ClassifierCounterFactualMilp):
             featuresPossibleValues=False,
             featuresActionnability=False,
             oneHotEncoding=False,
+            boundingBox=None,
             constraintsType=TreeConstraintsType.ExtendedFormulation,
             binaryDecisionVariables=BinaryDecisionVariables.LeftRight_lambda):
         ClassifierCounterFactualMilp.__init__(
@@ -26,6 +27,7 @@ class DecisionTreeCounterFactualMilp(ClassifierCounterFactualMilp):
             featuresActionnability=featuresActionnability,
             oneHotEncoding=oneHotEncoding)
         self.model.modelName = "DecisionTreeCounterFactualMilp"
+        self.boundingBox = boundingBox
         # Specify formulation parameters of forest MILP
         self.constraintsType = constraintsType
         self.binaryDecisionVariables = binaryDecisionVariables
@@ -149,6 +151,8 @@ class DecisionTreeCounterFactualMilp(ClassifierCounterFactualMilp):
         # Add constraints on features type and actionability
         self.addActionnabilityConstraints()
         self.addOneHotEncodingConstraints()
+        # Add bounds constraints of features
+        self.addBoundingBoxConstraints(boundingBox=self.boundingBox)
         # Add constraint on target class
         self._add_target_class_constraints()
         self.initObjective()


### PR DESCRIPTION
- New function `addBoundingBoxConstraints` added to limit explanations in a certain hypercube by adding lower and upper bound constraint to the MILP. 
- `format_explanation` function repaired so it doesn't change the parameter `x_exp`. 