### PR TITLE
Fix column dtype in Mapper initialization

### DIFF
--- a/ocean/abc/_mapper.py
+++ b/ocean/abc/_mapper.py
@@ -139,7 +139,7 @@ class Mapper[V: Value](Mapping[Key, V]):
         if isinstance(mapping, Mapper):
             columns = mapping.columns
         elif columns is None:
-            columns = pd.Index([])
+            columns = pd.Index([], dtype=object)
 
         return mapping, columns
 


### PR DESCRIPTION
Change the default dtype of columns in Mapper initialization to object for better compatibility.