### PR TITLE
Replace manual method with efficient propagation in FeatureVar and TreeVar

### DIFF
--- a/ocean/cp/_variables/_feature.py
+++ b/ocean/cp/_variables/_feature.py
@@ -33,8 +33,7 @@ class FeatureVar(Var, FeatureKeeper):
             self._mu = mu
         elif self.is_one_hot_encoded:
             u = self._add_u(model)
-            #model.Add(cp.LinearExpr.Sum(list(u.values())) == 1) # Old, manual way
-            model.AddExactlyOne(list(u.values()))  # Allows for more efficient propagation
+            model.AddExactlyOne(list(u.values()))
             self._u = u
             return
 

--- a/ocean/cp/_variables/_tree.py
+++ b/ocean/cp/_variables/_tree.py
@@ -24,9 +24,8 @@ class TreeVar(Var, TreeKeeper, Mapping[NonNegativeInt, cp.IntVar]):
     def build(self, model: BaseModel) -> None:
         name = self.PATH_VAR_NAME_FMT.format(name=self._name)
         self._path = self._add_path(model=model, name=name)
-        #model.Add(cp.LinearExpr.Sum(*self._path.values()) == 1) # Old, manual way
-        model.AddExactlyOne(*self._path.values())  # Allows for more efficient propagation
-        
+        model.AddExactlyOne(*self._path.values())
+
     def __len__(self) -> int:
         return self.n_nodes
 


### PR DESCRIPTION
Replace the old manual method of enforcing constraints with a more efficient propagation approach using `AddExactlyOne` in both `FeatureVar` and `TreeVar`.